### PR TITLE
-j1 -> RUST_TEST_THEADS=1

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -29,7 +29,7 @@ run_test_suite() {
   cargo build --target $TARGET --verbose
 
   if [ "$CHANNEL" = "nightly" ]; then
-    cargo test -j1 --target $TARGET
+    RUST_TEST_THREADS=1 cargo test --target $TARGET
   fi
 }
 


### PR DESCRIPTION
the former limits the compilation phase to one rustc process, the later
executes the tests in a single thread. We actually want the later.