### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ is also installed.
 cargo install xargo
 ```
 
+If building on OSX 10.10 or greater, compilation of libssh2-sys will 
+[fail due to missing OpenSSL headers](https://github.com/alexcrichton/ssh2-rs).
+Make sure OpenSSL is installed via HomeBrew, then run the following command:
+
+```
+OPENSSL_ROOT_DIR=/usr/local/opt/openssl/ cargo install xargo
+```
+
 ## License
 
 Licensed under either of


### PR DESCRIPTION
Just added a note to the readme about installation on OSX.
Libssh2 won't build by default because the OpenSSL headers were removed in OSX versions 10.10+. The fix is to install via Homebrew then set the environment so CMake can find them.

Again, thanks for xargo - it's awesome!

```cargo build``` fails with the following:

```
--- stderr
fatal: Not a git repository (or any of the parent directories): .git
CMake Error at /usr/local/Cellar/cmake/3.1.1_1/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:138 (message):
  Could NOT find OpenSSL, try to set the path to OpenSSL root folder in the
  system variable OPENSSL_ROOT_DIR (missing: OPENSSL_INCLUDE_DIR)
```