### PR TITLE
Add fix to display the current version of the crate

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -221,7 +221,7 @@ fn parse_args() -> CargoResult<(Command, Option<Target>, bool, bool, Option<Stri
             }
 
             if arg == "--version" {
-                println!("xargo version {}", CURRENT_VERSION); 
+                println!("xargo {}", CURRENT_VERSION); 
             }
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,9 @@ use cargo::util::{self, CargoResult, ChainError, Config, Filesystem};
 use rustc_cfg::Cfg;
 use rustc_version::Channel;
 
+// Get the current version of this crate
+const CURRENT_VERSION: &'static str = env!("CARGO_PKG_VERSION");
+
 mod sysroot;
 
 fn main() {
@@ -215,6 +218,10 @@ fn parse_args() -> CargoResult<(Command, Option<Target>, bool, bool, Option<Stri
 
             if arg == "doc" {
                 is_cargo_doc = true;
+            }
+
+            if arg == "--version" {
+                println!("xargo version {}", CURRENT_VERSION); 
             }
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -220,7 +220,7 @@ fn parse_args() -> CargoResult<(Command, Option<Target>, bool, bool, Option<Stri
                 is_cargo_doc = true;
             }
 
-            if arg == "--version" {
+            if arg == "-V" || arg == "--version" {
                 println!("xargo {}", CURRENT_VERSION); 
             }
         }


### PR DESCRIPTION
* Add a constant that get the current version of the crate
* Override `--version` option to display the current version of the crate and the current version of cargo