### PR TITLE
try to build all std dependencies including std

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Xargo will now try to build every crate "below" `std`, i.e. all its
+  dependencies, in topological order. This makes Xargo robust against changes in
+  the `std` facade as it no longer depends on hard coded crate names like
+  `rustc_unicode`.
+
 ## [v0.2.1] - 2016-10-22
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,12 +1,14 @@
 [root]
 name = "xargo"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
+ "daggy 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs2 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-cfg 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -41,6 +43,14 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "daggy"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "petgraph 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "dbghelp-sys"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -50,12 +60,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "dtoa"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "error-chain"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "fs2"
@@ -73,6 +93,11 @@ version = "0.3.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "itoa"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -85,6 +110,19 @@ dependencies = [
 name = "libc"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "num-traits"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "petgraph"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fixedbitset 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "rand"
@@ -121,6 +159,22 @@ dependencies = [
 name = "semver"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde_json"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "dtoa 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.8.16 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "tempdir"
@@ -161,18 +215,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum backtrace 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "346d7644f0b5f9bc73082d3b2236b69a05fd35cce0cfa3724e184e6a5c9e2a2f"
 "checksum backtrace-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ff73785ae8e06bb4a7b09e09f06d7434f9748b86d2f67bdf334b603354497e08"
 "checksum cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de1e760d7b6535af4241fca8bd8adf68e2e7edacc6b29f5d399050c5e48cf88c"
+"checksum daggy 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d6a9b61ac11d223e884f431772d311087644e4710c1555d7db270cefb5fb9c69"
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
+"checksum dtoa 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0dd841b58510c9618291ffa448da2e4e0f699d984d436122372f446dae62263d"
 "checksum error-chain 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bd5c82c815138e278b8dcdeffc49f27ea6ffb528403e9dea4194f2e3dd40b143"
+"checksum fixedbitset 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "88c3c33fc4c00db33f5174eb98aea809c4c007db0b71351d810a7e094ea3b64d"
 "checksum fs2 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "bcd414e5a1a979b931bb92f41b7a54106d3f6d2e6c253e9ce943b7cd468251ef"
 "checksum gcc 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)" = "91ecd03771effb0c968fd6950b37e89476a578aaf1c70297d8e92b6516ec3312"
+"checksum itoa 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ae3088ea4baeceb0284ee9eea42f591226e6beaecf65373e41b38d95a1b8e7a1"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)" = "408014cace30ee0f767b1c4517980646a573ec61a57957aeeabcac8ac0a02e8d"
+"checksum num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "a16a42856a256b39c6d3484f097f6713e14feacd9bfb02290917904fae46c81c"
+"checksum petgraph 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1a6f465be0adaa474e5692d4cb24732382476bb75fa84798b9f8fd820e1ad6e6"
 "checksum rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "2791d88c6defac799c3f20d74f094ca33b9332612d9aef9078519c82e4fe04a5"
 "checksum rustc-cfg 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37937dfed502ccc4e644c3cc272222e31adc2b1f5d215f6f8f8e1a422072e516"
 "checksum rustc-demangle 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "662b2795f21ff17df7c4c50c1d955c8b5fa9eaddd1cf1bb32f8de2372ffd989b"
 "checksum rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)" = "6159e4e6e559c81bd706afe9c8fd68f547d3e851ce12e76b1de7914bab61691b"
 "checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
 "checksum semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
+"checksum serde 0.8.16 (registry+https://github.com/rust-lang/crates.io-index)" = "1105e65d0a0b212d2d735c8b5a4f6aba2adc501e8ad4497e9f1a39e4c4ac943e"
+"checksum serde_json 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1cb6b19e74d9f65b9d03343730b643d729a446b29376785cd65efdff4675e2fc"
 "checksum tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "87974a6f5c1dfb344d733055601650059a3363de2a6104819293baff662132d6"
 "checksum toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "736b60249cb25337bc196faa43ee12c705e426f3d55c214d73a4e7be06f92cb4"
 "checksum walkdir 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c66c0b9792f0a765345452775f3adbd28dde9d33f30d13e5dcc5ae17cf6f3780"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,13 @@ repository = "https://github.com/japaric/xargo"
 version = "0.2.1"
 
 [dependencies]
+daggy = "0.4.1"
 error-chain = "0.5.0"
 fs2 = "0.2.5"
 libc = "0.2.16"
 rustc-cfg = "0.2.0"
 rustc_version = "0.1.7"
+serde_json = "0.8.3"
 tempdir = "0.3.5"
 toml = "0.2.1"
 walkdir = "0.1.8"

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -5,6 +5,7 @@ run() {
     # will be owned by root
     mkdir -p target
 
+    # FIXME(#82) `/rust` should be mounted as read-only
     docker build -t $1 ci/docker/$1
     docker run \
            --rm \
@@ -19,7 +20,7 @@ run() {
            -v $HOME/.cargo:/cargo \
            -v `pwd`/target:/target \
            -v `pwd`:/checkout:ro \
-           -v `rustc --print sysroot`:/rust:ro \
+           -v `rustc --print sysroot`:/rust \
            -w /checkout \
            -it $1 \
            sh -c "HOME=/tmp PATH=\$PATH:/rust/bin ci/run.sh"

--- a/src/dag.rs
+++ b/src/dag.rs
@@ -1,0 +1,162 @@
+// TODO de-unwrap-ify
+
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+use std::process::Command;
+
+use daggy::{Dag, NodeIndex, Walker};
+use serde_json::Value;
+use serde_json;
+
+use CommandExt;
+use errors::*;
+
+/// Dependency graph of the `std` crate
+pub struct DependencyGraph {
+    dag: Dag<String, ()>,
+}
+
+impl DependencyGraph {
+    pub fn new() -> Self {
+        DependencyGraph { dag: Dag::new() }
+    }
+
+    pub fn add_edge(&mut self, parent: &str, child: &str) {
+        let parent = self.add_node(parent);
+
+        if let Some(child) = self.get_node(child) {
+            self.dag.add_edge(parent, child, ()).unwrap();
+            return;
+        }
+
+        self.dag.add_child(parent, (), child.to_owned());
+    }
+
+    /// Tries to compile as much of the dependency graph as possible
+    pub fn compile<F>(&self, mut f: F) -> Result<()>
+        where F: FnMut(&str) -> Result<bool>
+    {
+        let mut failures = vec![];
+        let mut successes = vec![];
+
+        self.compile_(self.get_node("std").unwrap(),
+                      &mut successes,
+                      &mut failures,
+                      &mut f)
+            .map(|_| {})
+    }
+
+    fn compile_<F>(&self,
+                   pkg: NodeIndex,
+                   successes: &mut Vec<NodeIndex>,
+                   failures: &mut Vec<NodeIndex>,
+                   f: &mut F)
+                   -> Result<bool>
+        where F: FnMut(&str) -> Result<bool>
+    {
+        let mut at_least_one_dep_failed = false;
+
+        for (_, child) in self.dag.children(pkg).iter(&self.dag) {
+            if !try!(self.compile_(child, successes, failures, f)) {
+                at_least_one_dep_failed = true;
+            }
+        }
+
+        if at_least_one_dep_failed {
+            failures.push(pkg);
+            Ok(false)
+        } else if failures.contains(&pkg) {
+            Ok(false)
+        } else if successes.contains(&pkg) {
+            Ok(true)
+        } else {
+            if try!(f(self.name_of(pkg))) {
+                successes.push(pkg);
+                Ok(true)
+            } else {
+                failures.push(pkg);
+                Ok(false)
+            }
+        }
+    }
+
+    fn add_node(&mut self, pkg: &str) -> NodeIndex {
+        if let Some(i) = self.dag
+            .raw_nodes()
+            .iter()
+            .enumerate()
+            .filter(|&(_, ref node)| node.weight == pkg)
+            .map(|(i, _)| i)
+            .next() {
+            return NodeIndex::new(i);
+        }
+
+        self.dag.add_node(pkg.to_owned());
+
+        NodeIndex::new(self.dag.raw_nodes().len() - 1)
+    }
+
+    fn get_node(&self, pkg: &str) -> Option<NodeIndex> {
+        self.dag
+            .raw_nodes()
+            .iter()
+            .enumerate()
+            .filter(|&(_, ref node)| node.weight == pkg)
+            .map(|(i, _)| NodeIndex::new(i))
+            .next()
+    }
+
+    fn name_of(&self, idx: NodeIndex) -> &str {
+        &self.dag.raw_nodes()[idx.index()].weight
+    }
+}
+
+
+/// Builds the dependency graph of the `std` crate
+pub fn build(rust_src: &Path) -> Result<DependencyGraph> {
+    let metadata: Value = try!(serde_json::from_str(&try!(Command::new("cargo")
+            .arg("metadata")
+            .arg("--all-features")
+            .arg("--manifest-path")
+            .arg(rust_src.join("src/libstd/Cargo.toml"))
+            .run_and_get_stdout()))
+        .chain_err(|| "couldn't parse the output of `cargo metadata`"));
+
+    let package = metadata.pointer("/packages")
+        .unwrap()
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|p| (p.pointer("/name").unwrap().as_str().unwrap(), p))
+        .collect::<HashMap<_, _>>();
+
+    let mut to_visit = vec![package["std"]];
+    let mut visited = HashSet::new();
+
+    let mut dg = DependencyGraph::new();
+    while let Some(current_package) = to_visit.pop() {
+        let parent =
+            current_package.pointer("/name").unwrap().as_str().unwrap();
+
+        visited.insert(parent);
+
+        let deps = current_package.pointer("/dependencies")
+            .unwrap()
+            .as_array()
+            .unwrap();
+
+        for dep in deps {
+            if dep.pointer("/kind").and_then(|v| v.as_str()) != Some("build") {
+                let child = dep.pointer("/name").unwrap().as_str().unwrap();
+
+                if !visited.contains(&child) {
+                    to_visit.push(&package[child]);
+                }
+
+                dg.add_edge(parent, child);
+            }
+        }
+    }
+
+    Ok(dg)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -246,9 +246,10 @@ impl CommandExt for Command {
             .chain_err(|| format!("failed to execute {}", cmd)));
 
         if !output.status.success() {
-            try!(Err(format!("{} failed with exit status: {:?}",
+            try!(Err(format!("{} failed with exit status: {:?}.\nstderr:\n{}",
                              cmd,
-                             output.status.code())))
+                             output.status.code(),
+                             String::from_utf8_lossy(&output.stderr))))
         }
 
         Ok(try!(String::from_utf8(output.stdout)


### PR DESCRIPTION
this makes Xargo robust against changes in the std facade as all the
crate names that were hardcoded in Xargo, e.g. `rustc_unicode`, have
been removed.

The downside is that this also worsens the user experience because when
Xargo fails to build one of std dependencies it will simply regurgitate
the error to stderr.

cc @brson with this change, I won't get mad if you change the std facade :smile:.