### PR TITLE
Require sysroot for unsupported musl targets

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-aaaaaa#![allow(dead_code)]
+#![allow(dead_code)]
 
 extern crate daggy;
 #[macro_use]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code)]
+aaaaaa#![allow(dead_code)]
 
 extern crate daggy;
 #[macro_use]
@@ -205,6 +205,9 @@ impl Target {
         match *self {
             Target::BuiltIn { ref triple } => {
                 match &triple[..] {
+                    "arm-unknown-linux-musleabi" |
+                    "arm-unknown-linux-musleabihf" |
+                    "armv7-unknown-linux-musleabihf" |
                     "thumbv6m-none-eabi" |
                     "thumbv7m-none-eabi" |
                     "thumbv7em-none-eabi" |


### PR DESCRIPTION
These musl targets aren't officially supported and thus don't have a pre-compiled `std` available for download.