### PR TITLE
accept XARGO_RUST_SRC on the nightly channel too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- `XARGO_RUST_SRC` is now used when working with nightly Rust and it has
+  precedence over the `rust-src` component.
+
 ## [v0.3.1] - 2016-12-30
 
 ### Added

--- a/src/rustc.rs
+++ b/src/rustc.rs
@@ -42,11 +42,8 @@ pub struct Src {
 }
 
 impl Src {
-    pub fn from_env() -> Result<Self> {
-        Ok(env::var_os("XARGO_RUST_SRC").map(|s| Src { path: PathBuf::from(s) })
-            .ok_or("The XARGO_RUST_SRC env variable must be set and \
-                    point to the Rust source directory when working \
-                    with the 'dev' channel")?)
+    pub fn from_env() -> Option<Self> {
+        env::var_os("XARGO_RUST_SRC").map(|s| Src { path: PathBuf::from(s) })
     }
 
     pub fn path(&self) -> &Path {


### PR DESCRIPTION
and give it precedence over the `rust-src` component