### PR TITLE
allow "multi-stage" sysroot builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,9 +43,16 @@ install:
   - sh ci/install.sh
   # NOTE(sed) work around for #36501
   - source ~/.cargo/env &&
-      rustup component add rust-src &&
-      find $(rustc --print sysroot) -name Cargo.toml -print0 | xargs -0 sed -i '/"dylib"/d' ||
+      rustup component add rust-src ||
       true
+  - case $TRAVIS_OS_NAME in
+      linux)
+        find $(rustc --print sysroot) -name Cargo.toml -print0 | xargs -0 sed -i '/"dylib"/d';
+        ;;
+      osx)
+        find $(rustc --print sysroot) -name Cargo.toml -print0 | xargs -0 sed -i '' '/"dylib"/d';
+        ;;
+      esac
 
 script:
   - sh ci/script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ install:
   # NOTE(sed) work around for #36501
   - source ~/.cargo/env &&
       rustup component add rust-src &&
-      sed -i '/"dylib"/d' $(rustc --print sysroot)/**/Cargo.toml ||
+      find $(rustc --print sysroot) -name Cargo.toml -print0 | xargs -0 sed -i '/"dylib"/d' ||
       true
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,11 @@ matrix:
 
 install:
   - sh ci/install.sh
-  - source ~/.cargo/env && rustup component add rust-src || true
+  # NOTE(sed) work around for #36501
+  - source ~/.cargo/env &&
+      rustup component add rust-src &&
+      sed -i '/"dylib"/d' $(rustc --print sysroot)/**/Cargo.toml ||
+      true
 
 script:
   - sh ci/script.sh

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -42,10 +42,11 @@ impl Rustflags {
     }
 
     /// Stringifies these flags for Xargo consumption
-    pub fn for_xargo(mut self, home: &Home) -> String {
-        self.flags.push("--sysroot".to_owned());
-        self.flags.push(home.display().to_string());
-        self.flags.join(" ")
+    pub fn for_xargo(&self, home: &Home) -> String {
+        let mut flags = self.flags.clone();
+        flags.push("--sysroot".to_owned());
+        flags.push(home.display().to_string());
+        flags.join(" ")
     }
 }
 

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -311,6 +311,7 @@ impl HProject {
     }
 
     /// Adds a `Xargo.toml` to the project
+    #[cfg(not(windows))]
     fn xargo_toml(&self, toml: &str) -> Result<()> {
         write(&self.td.path().join("Xargo.toml"), false, toml)
     }


### PR DESCRIPTION
with this is now possible to build the `test` crate which doesn't
explicitly depend on `std`.

This Xargo.toml

``` toml
[dependencies.std]
features = ["panic_unwind"]
# stage = 0 # implicit

[dependencies.test]
stage = 1
```

Builds the sysroot in two stages. First, Xargo builds the `std`
facade, the stage 0, turns that into a partial sysroot and then builds
the `test` crate, the stage 1, against that partial sysroot. Finally,
the stage 0 artifacts and the stage 1 artifacts are then merged into the
sysroot that will be used to build the application.

The result is that you can use `xargo test` with this Xargo.toml.

---

cc @jackpot51