### PR TITLE
allow inserting foreign crates into the sysroot

### DIFF
--- a/src/sysroot.rs
+++ b/src/sysroot.rs
@@ -285,10 +285,14 @@ impl Blueprint {
                     0
                 };
 
-                let path =
-                    src.path().join(format!("lib{}", k)).display().to_string();
+                if !map.contains_key("path") && !map.contains_key("git") {
+                    let path = src.path()
+                        .join(format!("lib{}", k))
+                        .display()
+                        .to_string();
 
-                map.insert("path".to_owned(), Value::String(path));
+                    map.insert("path".to_owned(), Value::String(path));
+                }
 
                 blueprint.push(stage, k, map);
             } else {


### PR DESCRIPTION
this is mainly to support [steed] and other `std` drop in replacements

For example, with this Xargo.toml

``` toml
[dependencies.collections]  # `steed`s dependencies

[dependencies.std]  # use `steed` as if it were the real `std`
git = "https://github.com/japaric/steed"
stage = 1
```

you can use `xargo build` to compile your program against `steed`.

[steed]: https://github.com/japaric/steed

cc japaric/steed#20