### PR TITLE
improve error message when the `rust-src` component is missing

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -11,11 +11,16 @@ main() {
         target=x86_64-apple-darwin
     fi
 
+    local tag=$(git ls-remote --tags --refs --exit-code https://github.com/japaric/cross \
+                    | cut -d/ -f3 \
+                    | grep -E '^v[0.1.0-9.]+$' \
+                    | $sort --version-sort \
+                    | tail -n1)
     curl -LSfs https://japaric.github.io/trust/install.sh | \
         sh -s -- \
            --force \
            --git japaric/cross \
-           --tag v0.1.4 \
+           --tag $tag \
            --target $target
 }
 

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -7,8 +7,10 @@ main() {
     local target=
     if [ $TRAVIS_OS_NAME = linux ]; then
         target=x86_64-unknown-linux-gnu
+        sort=sort
     else
         target=x86_64-apple-darwin
+        sort=gsort  # for `sort --sort-version`, from brew's coreutils.
     fi
 
     local tag=$(git ls-remote --tags --refs --exit-code https://github.com/japaric/cross \

--- a/src/rustc.rs
+++ b/src/rustc.rs
@@ -70,17 +70,19 @@ impl Sysroot {
             return Ok(Src { path: src.join("rust/src") });
         }
 
-        for e in WalkDir::new(src) {
-            let e = e.chain_err(|| "couldn't walk the sysroot")?;
+        if src.exists() {
+            for e in WalkDir::new(src) {
+                let e = e.chain_err(|| "couldn't walk the sysroot")?;
 
-            // Looking for $SRC/libstd/Cargo.toml
-            if e.file_type().is_file() && e.file_name() == "Cargo.toml" {
-                let toml = e.path();
+                // Looking for $SRC/libstd/Cargo.toml
+                if e.file_type().is_file() && e.file_name() == "Cargo.toml" {
+                    let toml = e.path();
 
-                if let Some(std) = toml.parent() {
-                    if let Some(src) = std.parent() {
-                        if std.file_name() == Some(OsStr::new("libstd")) {
-                            return Ok(Src { path: src.to_owned() });
+                    if let Some(std) = toml.parent() {
+                        if let Some(src) = std.parent() {
+                            if std.file_name() == Some(OsStr::new("libstd")) {
+                                return Ok(Src { path: src.to_owned() });
+                            }
                         }
                     }
                 }

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -731,6 +731,7 @@ fn host_twice() {
 // component (cf. #36501) from within the appveyor environment
 #[cfg(feature = "dev")]
 #[cfg(not(windows))]
+#[ignore]
 #[test]
 fn test() {
     fn run() -> Result<()> {


### PR DESCRIPTION
now you get:

```
$ xargo build
error: `rust-src` component not found. Run `rustup component add rust-src`.
note: run with `RUST_BACKTRACE=1` for a backtrace
```

closes #124