### PR TITLE
Pass `-C metadata` during sysroot builds

### DIFF
--- a/src/sysroot.rs
+++ b/src/sysroot.rs
@@ -73,6 +73,7 @@ version = "0.0.0"
             let mut cmd = Command::new("cargo");
             let mut flags = rustflags.for_xargo(home);
             flags.push_str(" -Z force-unstable-if-unmarked");
+            flags.push_str(" -C metadata=xargo");
             cmd.env("RUSTFLAGS", flags);
             cmd.env_remove("CARGO_TARGET_DIR");
             cmd.arg("build");


### PR DESCRIPTION
This allows for Cargo/Xargo to properly distinguish between crates that are present both in the sysroot and included as `Cargo.toml` dependencies in downstream crates.

Not sure if it matters exactly what string is passed to the metadata argument or not, feel free to advise if it should be something better.