### PR TITLE
print RUSTFLAGS in verbose mode

### DIFF
--- a/src/sysroot.rs
+++ b/src/sysroot.rs
@@ -3,6 +3,7 @@ use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::path::PathBuf;
 use std::process::Command;
+use std::io::{self, Write};
 
 use rustc_version::VersionMeta;
 use tempdir::TempDir;
@@ -73,6 +74,9 @@ version = "0.0.0"
             let mut cmd = Command::new("cargo");
             let mut flags = rustflags.for_xargo(home);
             flags.push_str(" -Z force-unstable-if-unmarked");
+            if verbose {
+                writeln!(io::stderr(), "+ RUSTFLAGS={:?}", flags).ok();
+            }
             cmd.env("RUSTFLAGS", flags);
             cmd.env_remove("CARGO_TARGET_DIR");
             cmd.arg("build");

--- a/src/xargo.rs
+++ b/src/xargo.rs
@@ -1,6 +1,7 @@
 use std::path::{Display, PathBuf};
 use std::process::{Command, ExitStatus};
 use std::{env, mem};
+use std::io::{self, Write};
 
 use toml::Value;
 use rustc_version::VersionMeta;
@@ -32,7 +33,11 @@ pub fn run(
         );
     }
 
-    cmd.env("RUSTFLAGS", rustflags.for_xargo(home));
+    let flags = rustflags.for_xargo(home);
+    if verbose {
+        writeln!(io::stderr(), "+ RUSTFLAGS={:?}", flags).ok();
+    }
+    cmd.env("RUSTFLAGS", flags);
 
     let locks = (home.lock_ro(&meta.host), home.lock_ro(cmode.triple()));
 


### PR DESCRIPTION
It took me a little while to realize that xargo does add some flags on its own here. Having this output would have helped :)