### PR TITLE
use Cargo.lock file from rust-src if present

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,8 @@
 #[macro_use]
 extern crate error_chain;
 extern crate fs2;
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")),
+          target_os = "macos"))]
 extern crate libc;
 extern crate rustc_version;
 extern crate serde_json;


### PR DESCRIPTION
This ensures we are using the exact versions of the packages that were used to build the libstd of this Rust release.

Cc #162