### PR TITLE
Search for Xargo.toml in parent directories.

### DIFF
--- a/src/xargo.rs
+++ b/src/xargo.rs
@@ -116,11 +116,10 @@ impl Toml {
 }
 
 pub fn toml(root: &Root) -> Result<Option<Toml>> {
-    let p = root.path().join("Xargo.toml");
-
-    if p.exists() {
-        util::parse(&p).map(|t| Some(Toml { table: t }))
-    } else {
+    if let Some(p) = util::search(root.path(), "Xargo.toml") {
+        util::parse(&p.join("Xargo.toml")).map(|t| Some(Toml { table: t }))
+    }
+    else {
         Ok(None)
     }
 }


### PR DESCRIPTION
So far, xargo expected the Xargo.toml in the directory of the Cargo.toml. This patch searches for the Xargo.toml by walking up the directory hierarchy. This is useful if a workspace is used, leading, for example, to one Cargo.toml with the workspace and multiple Cargo.toml files for the members of the workspace. With this patch, it is no longer necessary to have one Xargo.toml for each Cargo.toml, but only one next to the workspace, for example.