### PR TITLE
Copy bin directory to host sysroot

### DIFF
--- a/src/sysroot.rs
+++ b/src/sysroot.rs
@@ -249,6 +249,17 @@ pub fn update(
         &dst,
     )?;
 
+    let bin_dst = lock.parent().join("bin");
+    util::mkdir(&bin_dst)?;
+    util::cp_r(
+        &sysroot
+            .path()
+            .join("lib/rustlib")
+            .join(&meta.host)
+            .join("bin"),
+        &bin_dst,
+    )?;
+
     util::write(&hfile, hash)?;
 
     Ok(())


### PR DESCRIPTION
Allows custom targets to use the copy of `lld` bundled with Rust.

cc https://github.com/rust-lang/rust/issues/48772