### PR TITLE
Update Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,7 +223,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "xargo"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "error-chain 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs2 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
Since #200, `Cargo.lock` is considered dirty after Xargo has been built. This is particularly annoying when using Xargo as a Git submodule such as in tock/libtock-rs#18.

This PR updates `Cargo.lock` s.t. it will no longer be considered dirty after building Xargo.