### PR TITLE
Allowing stable channel rustc in Rust's style

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -140,13 +140,21 @@ fn run() -> Result<ExitStatus> {
                 sysroot.src()?
             },
             Channel::Stable | Channel::Beta => {
-                writeln!(
-                    io::stderr(),
-                    "WARNING: the sysroot can't be built for the {:?} channel. \
-                     Switch to nightly.",
-                    meta.channel
-                ).ok();
-                return cargo::run(&args, verbose);
+                if env::var("RUSTC_BOOTSTRAP").is_ok() {
+                    if let Some(src) = rustc::Src::from_env() {
+                        src
+                    } else {
+                        sysroot.src()?
+                    }
+                } else {
+                    writeln!(
+                        io::stderr(),
+                        "WARNING: the sysroot can't be built for the {:?} channel. \
+                        Switch to nightly.",
+                        meta.channel
+                    ).ok();
+                    return cargo::run(&args, verbose);
+                }
             }
         };
 


### PR DESCRIPTION
[rust-sgx-sdk](https://github.com/baidu/rust-sgx-sdk) author here. We are facing a problem when using xargo in production. In production, we want to use stable branch of rust to compile the sysroot to achieve stability. However, xargo doesn't allow us to do this. We found that Rust provides a switch [`RUSTC_BOOTSTRAP`](https://github.com/rust-lang/rust/blob/b99172311c640c33f70676df7f75a899a999711c/src/libsyntax/feature_gate.rs#L1953)  which enables unstable features and allows stable branch rustc compiles latest libstd. And this option is enabled by default during bootstrap stage of building rust. So we believe that `RUSTC_BOOTSTRAP` is an acceptable solution for xargo and it's a desired feature.

Currently we have to maintain a branch of xargo for it. We wish it could be merged to mainstream. It's really helpful to us. Thanks!