### PR TITLE
Support absolute target JSON paths

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -56,9 +56,18 @@ impl CompilationMode {
         Ok(())
     }
 
+    /// Returns the condensed target triple (removes any `.json` extension and path components).
     fn triple(&self) -> &str {
         match *self {
             CompilationMode::Cross(ref target) => target.triple(),
+            CompilationMode::Native(ref triple) => triple,
+        }
+    }
+
+    /// Returns the original target triple passed to xargo (perhaps with `.json` extension).
+    fn orig_triple(&self) -> &str {
+        match *self {
+            CompilationMode::Cross(ref target) => target.orig_triple(),
             CompilationMode::Native(ref triple) => triple,
         }
     }
@@ -151,12 +160,7 @@ fn run() -> Result<ExitStatus> {
         };
 
         let cmode = if let Some(triple) = args.target() {
-            if Path::new(triple).is_file() {
-                bail!(
-                    "Xargo doesn't support files as an argument to --target. \
-                     Use `--target foo` instead of `--target foo.json`."
-                )
-            } else if triple == meta.host {
+            if triple == meta.host {
                 Some(CompilationMode::Native(meta.host.clone()))
             } else {
                 Target::new(triple, &cd, verbose)?.map(CompilationMode::Cross)

--- a/src/sysroot.rs
+++ b/src/sysroot.rs
@@ -124,7 +124,7 @@ version = "0.0.0"
             }
             cmd.arg("--manifest-path");
             cmd.arg(td.join("Cargo.toml"));
-            cmd.args(&["--target", cmode.triple()]);
+            cmd.args(&["--target", cmode.orig_triple()]);
 
             if verbose {
                 cmd.arg("-v");


### PR DESCRIPTION
Builds upon https://github.com/rust-lang/rust/pull/49019 and https://github.com/rust-lang/cargo/pull/5228 to provide a solution to https://github.com/rust-lang/cargo/issues/4905 and https://github.com/japaric/xargo/issues/194.

The idea is that we allow targets ending in `*.json` (they were forbidden before) and convert them to canonicalized paths. Thus, they just work when compiling dependencies without the need to set the `RUST_TARGET_PATH` environment variable.

This PR just removes the explicit prohibition of paths as target and extends `Target::new` to handle such target paths. This should not lead to any breakage, because target paths ending in `.json` were explicitly forbidden before.