### PR TITLE
Force sysroot to have different hashes

### DIFF
--- a/src/sysroot.rs
+++ b/src/sysroot.rs
@@ -116,6 +116,7 @@ version = "0.0.0"
             }
             cmd.env("RUSTFLAGS", flags);
             cmd.env_remove("CARGO_TARGET_DIR");
+            cmd.env("__CARGO_DEFAULT_LIB_METADATA", "XARGO");
 
             // As of rust-lang/cargo#4788 Cargo invokes rustc with a changed "current directory" so
             // we can't assume that such directory will be the same as the directory from which


### PR DESCRIPTION
A terrible workaround a problem I found: If the sysroot and project share a dependency, it might cause conflicts, leading to confusing cargo errors.