### PR TITLE
Escape sysroot and manifest paths to remove whitespaces

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -45,7 +45,7 @@ impl Rustflags {
     pub fn for_xargo(&self, home: &Home) -> String {
         let mut flags = self.flags.clone();
         flags.push("--sysroot".to_owned());
-        flags.push(home.display().to_string());
+        flags.push(util::escape_argument_spaces(format!("{}", home.display())));
         flags.join(" ")
     }
 }
@@ -68,7 +68,7 @@ impl Rustdocflags {
     /// Stringifies these flags for Xargo consumption
     pub fn for_xargo(mut self, home: &Home) -> String {
         self.flags.push("--sysroot".to_owned());
-        self.flags.push(home.display().to_string());
+        self.flags.push(util::escape_argument_spaces(format!("{}", home.display())));
         self.flags.join(" ")
     }
 }

--- a/src/sysroot.rs
+++ b/src/sysroot.rs
@@ -129,7 +129,7 @@ version = "0.0.0"
                 }
             }
             cmd.arg("--manifest-path");
-            cmd.arg(td.join("Cargo.toml"));
+            cmd.arg(util::escape_argument_spaces(td.join("Cargo.toml").to_str().expect("This path doesn't contain valid UTF-8 characters")));
             cmd.args(&["--target", cmode.triple()]);
 
             if verbose {

--- a/src/util.rs
+++ b/src/util.rs
@@ -100,3 +100,13 @@ pub fn write(path: &Path, contents: &str) -> Result<()> {
         .write_all(contents.as_bytes())
         .chain_err(|| format!("couldn't write to {}", p))
 }
+
+pub fn escape_argument_spaces<S: Into<String>>(arg: S) -> String {
+    #[cfg(target_os = "windows")]
+    let escaped = arg.into().replace(" ", "%20");
+
+    #[cfg(not(target_os = "windows"))]
+    let escaped = arg.into().replace(" ", "\\ ");
+
+    escaped
+}


### PR DESCRIPTION
## Hopefully fixes #206 

Fixes an error on windows where paths with whitespaces don't get escaped at all, causing the error `error: multiple input filenames provided`. In my case it happens because my Windows username is "Axel Montini" and xargo doesn't like the space in the middle.
This commit adds a function in utils to escape a string and replace spaces with `%20` on windows or `\ ` on other operative systems.
I haven't tested this on a Unix machine, but it seems to work on windows.