### PR TITLE
Don't error on missing rustlib/$TRIPLE/bin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,7 +417,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "xargo"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "dirs 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/sysroot.rs
+++ b/src/sysroot.rs
@@ -276,16 +276,13 @@ pub fn update(
         &dst,
     )?;
 
-    let bin_dst = lock.parent().join("bin");
-    util::mkdir(&bin_dst)?;
-    util::cp_r(
-        &sysroot
-            .path()
-            .join("lib/rustlib")
-            .join(&meta.host)
-            .join("bin"),
-        &bin_dst,
-    )?;
+    let bin_src = sysroot.path().join("lib/rustlib").join(&meta.host).join("bin");
+    // copy the Rust linker if it exists
+    if bin_src.exists() {
+        let bin_dst = lock.parent().join("bin");
+        util::mkdir(&bin_dst)?;
+        util::cp_r(&bin_src, &bin_dst)?;
+    }
 
     util::write(&hfile, hash)?;
 


### PR DESCRIPTION
```
error: intermittent IO error while iterating directory `.../rust/build/x86_64-unknown-linux-gnu/stage2/lib/rustlib/x86_64-unknown-linux-gnu/bin`
caused by: IO error for operation on .../rust/build/x86_64-unknown-linux-gnu/stage2/lib/rustlib/x86_64-unknown-linux-gnu/bin: No such file or directory (os error 2)
caused by: No such file or directory (os error 2)
note: run with `RUST_BACKTRACE=1` for a backtrace
```