### PR TITLE
let environment overwrite cargo command

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -142,8 +142,14 @@ fn flags(config: Option<&Config>, target: &str, tool: &str) -> Result<Vec<String
     }
 }
 
+pub fn command() -> Command {
+    env::var_os("CARGO")
+        .map(Command::new)
+        .unwrap_or_else(|| Command::new("cargo"))
+}
+
 pub fn run(args: &Args, verbose: bool) -> Result<ExitStatus> {
-    Command::new("cargo")
+    command()
         .args(args.all())
         .run_and_get_status(verbose)
 }

--- a/src/sysroot.rs
+++ b/src/sysroot.rs
@@ -3,7 +3,6 @@ use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::io::{self, Write};
 use std::path::PathBuf;
-use std::process::Command;
 use std::{env, fs};
 
 use rustc_version::VersionMeta;
@@ -104,7 +103,7 @@ version = "0.0.0"
         util::write(&td.join("src/lib.rs"), "")?;
 
         let cargo = || {
-            let mut cmd = Command::new("cargo");
+            let mut cmd = cargo::command();
             let mut flags = rustflags.for_xargo(home);
             flags.push_str(" -Z force-unstable-if-unmarked");
             if verbose {

--- a/src/xargo.rs
+++ b/src/xargo.rs
@@ -1,5 +1,5 @@
 use std::path::{Display, PathBuf};
-use std::process::{Command, ExitStatus};
+use std::process::ExitStatus;
 use std::{env, mem};
 use std::io::{self, Write};
 
@@ -23,7 +23,7 @@ pub fn run(
     config: Option<&Config>,
     verbose: bool,
 ) -> Result<ExitStatus> {
-    let mut cmd = Command::new("cargo");
+    let mut cmd = cargo::command();
     cmd.args(args.all());
 
     if args.subcommand() == Some(Subcommand::Doc) {


### PR DESCRIPTION
This is needed in https://github.com/rust-lang/rust/pull/63162 to make xargo work during rustc bootstrap.

r? @jethrogb 