### PR TITLE
Use the lockfile shipped with rust-src

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ matrix:
       rust: nightly
       if: branch = staging OR branch = trying OR type = pull_request
     - env: TARGET=x86_64-unknown-linux-gnu
+      # Don't remove this target; test coverage in `smoke.rs` relies on us running at least
+      # one pinned toolchain.
       rust: nightly-2018-12-01 # old version without rustc-std-workspace-core
       if: branch = staging OR branch = trying
 

--- a/src/sysroot.rs
+++ b/src/sysroot.rs
@@ -99,13 +99,10 @@ version = "0.0.0"
             stoml.push_str(&profile.to_string())
         }
 
-        {
-            // Recent rust-src comes with a lockfile for libstd. Use it.
-            let lockfile = src.path().join("Cargo.lock");
-            if lockfile.exists() {
-                fs::copy(lockfile, &td.join("Cargo.lock")).chain_err(|| "couldn't copy lock file")?;
-            }
-        }
+        // rust-src comes with a lockfile for libstd. Use it.
+        let lockfile = src.path().join("..").join("Cargo.lock");
+        fs::copy(lockfile, &td.join("Cargo.lock")).chain_err(|| "couldn't copy lock file")?;
+
         util::write(&td.join("Cargo.toml"), &stoml)?;
         util::mkdir(&td.join("src"))?;
         util::write(&td.join("src/lib.rs"), "")?;

--- a/src/sysroot.rs
+++ b/src/sysroot.rs
@@ -101,7 +101,7 @@ version = "0.0.0"
 
         // rust-src comes with a lockfile for libstd. Use it.
         let lockfile = src.path().join("..").join("Cargo.lock");
-        fs::copy(lockfile, &td.join("Cargo.lock")).chain_err(|| "couldn't copy lock file")?;
+        fs::copy(lockfile, &td.join("Cargo.lock")).chain_err(|| "Cargo.lock file is missing from source dir")?;
 
         util::write(&td.join("Cargo.toml"), &stoml)?;
         util::mkdir(&td.join("src"))?;

--- a/src/sysroot.rs
+++ b/src/sysroot.rs
@@ -34,6 +34,7 @@ fn build(
     ctoml: &cargo::Toml,
     home: &Home,
     rustflags: &Rustflags,
+    src: &Src,
     sysroot: &Sysroot,
     hash: u64,
     verbose: bool,
@@ -98,6 +99,13 @@ version = "0.0.0"
             stoml.push_str(&profile.to_string())
         }
 
+        {
+            // Recent rust-src comes with a lockfile for libstd. Use it.
+            let lockfile = src.path().join("Cargo.lock");
+            if lockfile.exists() {
+                fs::copy(lockfile, &td.join("Cargo.lock")).chain_err(|| "couldn't copy lock file")?;
+            }
+        }
         util::write(&td.join("Cargo.toml"), &stoml)?;
         util::mkdir(&td.join("src"))?;
         util::write(&td.join("src/lib.rs"), "")?;
@@ -239,6 +247,7 @@ pub fn update(
             &ctoml,
             home,
             rustflags,
+            src,
             sysroot,
             hash,
             verbose,

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -827,7 +827,9 @@ stage = 1
     run!()
 }
 
-/// Test having a `[patch]` section
+/// Test having a `[patch]` section.
+/// The tag in the toml file needs to be updated any time the version of
+/// cc used by rustc is updated.
 #[cfg(feature = "dev")]
 #[test]
 fn host_patch() {
@@ -840,6 +842,7 @@ features = ["panic_unwind"]
 
 [patch.crates-io.cc]
 git = "https://github.com/alexcrichton/cc-rs"
+tag = "1.0.35"
 "#,
         )?;
         let stderr = project.build_and_get_stderr()?;

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -775,7 +775,7 @@ fn host_libtest() {
         let project = HProject::new(true)?;
 
         if std::env::var("TRAVIS_RUST_VERSION").ok().map_or(false,
-            |var| var.starts_with("nightly-2018"))
+            |var| var.starts_with("nightly-"))
         {
             // Testing an old version on CI, we need a different Xargo.toml.
             project.xargo_toml(
@@ -842,7 +842,7 @@ features = ["panic_unwind"]
 
 [patch.crates-io.cc]
 git = "https://github.com/alexcrichton/cc-rs"
-tag = "1.0.35"
+tag = "1.0.25"
 "#,
         )?;
         let stderr = project.build_and_get_stderr()?;
@@ -857,5 +857,10 @@ tag = "1.0.35"
         Ok(())
     }
 
-    run!()
+    // Only run this on pinned nightlies, to avoid having to update the version number all the time.
+    let is_pinned = std::env::var("TRAVIS_RUST_VERSION").ok().map_or(false,
+            |var| var.starts_with("nightly-"));
+    if is_pinned {
+        run!()
+    }
 }

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -272,7 +272,8 @@ struct HProject {
 
 impl HProject {
     fn new(test: bool) -> Result<Self> {
-        // There can only be one instance of this type at any point in time
+        // There can only be one instance of this type at any point in time.
+        // Needed to make sure we don't try to build multiple HOST libstds in parallel.
         lazy_static! {
             static ref ONCE: Mutex<()> = Mutex::new(());
         }
@@ -763,7 +764,7 @@ fn host_twice() {
 /// Check multi stage sysroot builds with `xargo test`
 #[cfg(feature = "dev")]
 #[test]
-fn test() {
+fn host_libtest() {
     fn run() -> Result<()> {
         let project = HProject::new(true)?;
 
@@ -802,7 +803,7 @@ features = [\"panic_unwind\"]
 /// Check multi stage sysroot builds with `xargo build`
 #[cfg(feature = "dev")]
 #[test]
-fn alloc() {
+fn host_liballoc() {
     fn run() -> Result<()> {
         let project = HProject::new(false)?;
 


### PR DESCRIPTION
This reverts a [prior revert](https://github.com/japaric/xargo/pull/190).
compiler-builtins is nowadays pulled in via crates.io, so let's give locking another shot.