### PR TITLE
clarify operating systems with available binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,6 @@ panic=abort`, for your target.
 $ cargo install xargo
 ```
 
-But we also have [binary releases] for Linux, macOS, and Windows.
-
 [binary releases]: https://github.com/japaric/xargo/releases
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -36,8 +36,6 @@ panic=abort`, for your target.
 $ cargo install xargo
 ```
 
-[binary releases]: https://github.com/japaric/xargo/releases
-
 ## Usage
 
 ### `no_std`

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ panic=abort`, for your target.
 $ cargo install xargo
 ```
 
-But we also have [binary releases] for the three major OSes.
+But we also have [binary releases] for Linux, macOS, and Windows.
 
 [binary releases]: https://github.com/japaric/xargo/releases
 


### PR DESCRIPTION
This is very much a nit. Feel free to close and discard this PR if you wish.

It may also be worth getting rid of this line entirely. It appears that since 0.3.12 there have
only been Windows binary releases (excluding one linux one in 0.3.13).