### PR TITLE
Pass message-format to the cargo building the sysroot

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,6 +6,7 @@ pub struct Args {
     all: Vec<String>,
     subcommand: Option<Subcommand>,
     target: Option<String>,
+    message_format: Option<String>
 }
 
 impl Args {
@@ -19,6 +20,10 @@ impl Args {
 
     pub fn target(&self) -> Option<&str> {
         self.target.as_ref().map(|s| &**s)
+    }
+
+    pub fn message_format(&self) -> Option<&str> {
+        self.message_format.as_ref().map(|s| &**s)
     }
 
     pub fn verbose(&self) -> bool {
@@ -37,6 +42,7 @@ pub fn args() -> Args {
 
     let mut sc = None;
     let mut target = None;
+    let mut message_format = None;
     {
         let mut args = all.iter();
         while let Some(arg) = args.next() {
@@ -48,6 +54,10 @@ pub fn args() -> Args {
                 target = args.next().map(|s| s.to_owned());
             } else if arg.starts_with("--target=") {
                 target = arg.splitn(2, '=').nth(1).map(|s| s.to_owned());
+            } else if arg == "--message-format" {
+                message_format = args.next().map(|s| s.to_owned());
+            } else if arg.starts_with("--message-format=") {
+                message_format = arg.splitn(2, '=').nth(1).map(|s| s.to_owned());
             }
         }
     }
@@ -56,5 +66,6 @@ pub fn args() -> Args {
         all: all,
         subcommand: sc,
         target: target,
+        message_format: message_format
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -187,6 +187,7 @@ fn run() -> Result<ExitStatus> {
                 &src,
                 &sysroot,
                 verbose,
+                args.message_format()
             )?;
             return xargo::run(
                 &args,

--- a/src/sysroot.rs
+++ b/src/sysroot.rs
@@ -38,6 +38,7 @@ fn build(
     sysroot: &Sysroot,
     hash: u64,
     verbose: bool,
+    message_format: Option<&str>
 ) -> Result<()> {
     const TOML: &'static str = r#"
 [package]
@@ -145,6 +146,9 @@ version = "0.0.0"
             cmd.arg("--manifest-path");
             cmd.arg(td.join("Cargo.toml"));
             cmd.args(&["--target", cmode.triple()]);
+            if let Some(format) = message_format {
+                cmd.args(&["--message-format", format]);
+            }
 
             if verbose {
                 cmd.arg("-v");
@@ -229,6 +233,7 @@ pub fn update(
     src: &Src,
     sysroot: &Sysroot,
     verbose: bool,
+    message_format: Option<&str>
 ) -> Result<()> {
     let ctoml = cargo::toml(root)?;
     let xtoml = xargo::toml(root)?;
@@ -248,6 +253,7 @@ pub fn update(
             sysroot,
             hash,
             verbose,
+            message_format,
         )?;
     }
 


### PR DESCRIPTION
Currently, `--message-format` is forwarded to the cargo building the final crate, but not when building the sysroot. This can break some tools that work by analyzing the output of `cargo build --message-format=json` when using xargo as a cargo replacement. (Split off from #217 )