### PR TITLE
Use RUSTC_BOOTSTRAP to build sysroot for stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,10 +323,6 @@ which will perform a normal sysroot build, followed by a 'check' build of *your 
 
 ## Caveats / gotchas
 
-- Xargo won't build a sysroot when used with stable or beta Rust. This is
-  because `std` and other standard crates depend on unstable features so it's
-  not possible to build the sysroot with stable or beta.
-
 - `std` is built as rlib *and* dylib. The dylib needs a panic library and an
   allocator.  If you do not specify the `panic-unwind` feature, you have to set
   `panic = "abort"` in `Cargo.toml`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ use std::path::{Path, PathBuf};
 use std::process::ExitStatus;
 use std::{env, io, process};
 
-use rustc_version::Channel;
+use rustc_version::Channel::*;
 
 use errors::*;
 use rustc::Target;
@@ -134,24 +134,15 @@ fn run(cargo_mode: XargoMode) -> Result<Option<ExitStatus>> {
         // We can't build sysroot with stable or beta due to unstable features
         let sysroot = rustc::sysroot(verbose)?;
         let src = match meta.channel {
-            Channel::Dev => rustc::Src::from_env().ok_or(
+            Dev => rustc::Src::from_env().ok_or(
                 "The XARGO_RUST_SRC env variable must be set and point to the \
                  Rust source directory when working with the 'dev' channel",
             )?,
-            Channel::Nightly => if let Some(src) = rustc::Src::from_env() {
+            Nightly | Stable | Beta => if let Some(src) = rustc::Src::from_env() {
                 src
             } else {
                 sysroot.src()?
             },
-            Channel::Stable | Channel::Beta => {
-                writeln!(
-                    io::stderr(),
-                    "WARNING: the sysroot can't be built for the {:?} channel. \
-                     Switch to nightly.",
-                    meta.channel
-                ).ok();
-                return cargo::run(&args, verbose).map(Some);
-            }
         };
 
         let cmode = if let Some(triple) = args.target() {

--- a/src/sysroot.rs
+++ b/src/sysroot.rs
@@ -129,6 +129,14 @@ version = "0.0.0"
             cmd.env("RUSTFLAGS", flags);
             cmd.env_remove("CARGO_TARGET_DIR");
 
+            // When building the sysroot or rust compiler with a beta or stable rustc binary the
+            // flag RUSTC_BOOTSTRAP can be set to 1 to allow rustc to allow the same features as
+            // the development channel. This is required as the rust compiler and sysroot make use
+            // of unstable features.
+            //
+            // See here: https://github.com/rust-lang/cargo/pull/5613
+            cmd.env("RUSTC_BOOTSTRAP", "1");
+
             // Workaround #261.
             //
             // If a crate is shared between the sysroot and a binary, we might


### PR DESCRIPTION
When building the sysroot or rust compiler with a beta or stable rustc
binary the flag RUSTC_BOOTSTRAP can be set to 1 to allow rustc to allow
the same features as the development channel. This is required as the
rust compiler and sysroot make use of unstable features.

See here: https://github.com/rust-lang/cargo/pull/5613

Fixes #225 