### PR TITLE
skip copy of windows-gnu libs in check-only mode

### DIFF
--- a/src/sysroot.rs
+++ b/src/sysroot.rs
@@ -55,7 +55,7 @@ version = "0.0.0"
     let dst = rustlib.parent().join("lib");
     util::mkdir(&dst)?;
 
-    if cmode.triple().contains("pc-windows-gnu") {
+    if cmode.triple().contains("pc-windows-gnu") && cargo_mode == XargoMode::Build {
         let src = &sysroot
             .path()
             .join("lib")

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -934,7 +934,7 @@ fn cargo_check_check_no_ctoml() {
         std::fs::remove_file(project.td.path().join("Cargo.toml"))
             .chain_err(|| format!("Could not remove Cargo.toml"))?;
 
-        // windows-gnu specifically needs some extra fiels to be copied for full builds;
+        // windows-gnu specifically needs some extra files to be copied for full builds;
         // make sure check-builds work without those files.
         let stderr = project.xargo_check_subcommand(None, Some("i686-pc-windows-gnu"))?;
         assert!(stderr.contains("Checking core"));


### PR DESCRIPTION
Unfortunately we cannot test `--target x86_64-pc-windows-gnu` until https://github.com/rust-lang/backtrace-rs/pull/297 lands and propagates. But I confirmed locally that using both together makes that target work on my Linux box.