### PR TITLE
Allow fallback on value package.rust-src if XARGO_RUST_SRC doesn't exist

### DIFF
--- a/src/rustc.rs
+++ b/src/rustc.rs
@@ -108,6 +108,12 @@ impl Sysroot {
     }
 }
 
+impl From<PathBuf> for Src {
+    fn from(path: PathBuf) -> Self {
+        Self { path }
+    }
+}
+
 #[derive(Debug)]
 pub enum Target {
     Builtin { triple: String },


### PR DESCRIPTION
This allows for including a `package` table in Xargo.toml, which optionally can contain a `rust-src` string specifying a rust source path in lieu of the existence of the `XARGO_RUST_SRC` environment variable.

Example `Xargo.toml`:
```toml
[package]
rust-src = "/home/jam/a/dev/rust-skyline/rust-std-skyline/src"

[dependencies.std]
stage = 0
```