### PR TITLE
make xargo fail on non-nightly, instead of continuing with the wrong sysroot

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,13 +144,12 @@ fn run(cargo_mode: XargoMode) -> Result<Option<ExitStatus>> {
                 sysroot.src()?
             },
             Channel::Stable | Channel::Beta => {
-                writeln!(
-                    io::stderr(),
-                    "WARNING: the sysroot can't be built for the {:?} channel. \
+                eprintln!(
+                    "ERROR: the sysroot can't be built for the {:?} channel. \
                      Switch to nightly.",
                     meta.channel
-                ).ok();
-                return cargo::run(&args, verbose).map(Some);
+                );
+                process::exit(1);
             }
         };
 


### PR DESCRIPTION
This will likely just lead to failures later, so we better don't continue.