### PR TITLE
avoid adding '/' or '..' to paths for better Windows compatibility

### DIFF
--- a/src/rustc.rs
+++ b/src/rustc.rs
@@ -72,11 +72,11 @@ impl Sysroot {
     /// Returns the path to Rust source, `$SRC`, where `$SRC/libstd/Carg.toml`
     /// exists
     pub fn src(&self) -> Result<Src> {
-        let src = self.path().join("lib/rustlib/src");
+        let src = self.path().join("lib").join("rustlib").join("src");
 
-        if src.join("rust/src/libstd/Cargo.toml").is_file() {
+        if src.join("rust").join("src").join("libstd").join("Cargo.toml").is_file() {
             return Ok(Src {
-                path: src.join("rust/src"),
+                path: src.join("rust").join("src"),
             });
         }
 

--- a/src/sysroot.rs
+++ b/src/sysroot.rs
@@ -104,7 +104,8 @@ version = "0.0.0"
         }
 
         // rust-src comes with a lockfile for libstd. Use it.
-        let lockfile = src.path().join("..").join("Cargo.lock");
+        let src_parent = src.path().parent().map(Path::to_path_buf).unwrap_or_else(|| src.path().join(".."));
+        let lockfile = src_parent.join("Cargo.lock");
         let target_lockfile = td.join("Cargo.lock");
         fs::copy(lockfile, &target_lockfile).chain_err(|| "Cargo.lock file is missing from source dir")?;
 
@@ -117,7 +118,7 @@ version = "0.0.0"
 
         util::write(&td.join("Cargo.toml"), &stoml)?;
         util::mkdir(&td.join("src"))?;
-        util::write(&td.join("src/lib.rs"), "")?;
+        util::write(&td.join("src").join("lib.rs"), "")?;
 
         let cargo = || {
             let mut cmd = cargo::command();
@@ -337,13 +338,14 @@ pub fn update(
     util::cp_r(
         &sysroot
             .path()
-            .join("lib/rustlib")
+            .join("lib")
+            .join("rustlib")
             .join(&meta.host)
             .join("lib"),
         &dst,
     )?;
 
-    let bin_src = sysroot.path().join("lib/rustlib").join(&meta.host).join("bin");
+    let bin_src = sysroot.path().join("lib").join("rustlib").join(&meta.host).join("bin");
     // copy the Rust linker if it exists
     if bin_src.exists() {
         let bin_dst = lock.parent().join("bin");

--- a/src/xargo.rs
+++ b/src/xargo.rs
@@ -58,7 +58,7 @@ impl Home {
     }
 
     fn path(&self, triple: &str) -> Filesystem {
-        self.path.join("lib/rustlib").join(triple)
+        self.path.join("lib").join("rustlib").join(triple)
     }
 
     pub fn lock_ro(&self, triple: &str) -> Result<FileLock> {


### PR DESCRIPTION
This should help with issues such as [this one](https://github.com/rust-lang/rust/pull/74146#issuecomment-655723028).