### PR TITLE
release xargo 0.3.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [v0.3.22] - 2020-07-29
+
+### Fixed
+
+- Fix for changed rustc directory layout.
+- Support relative XARGO_RUST_SRC.
+
 ## [v0.3.21] - 2020-07-11
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,7 +407,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "xargo"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "dirs 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["cli", "cross", "compilation", "std"]
 license = "MIT OR Apache-2.0"
 name = "xargo"
 repository = "https://github.com/japaric/xargo"
-version = "0.3.21"
+version = "0.3.22"
 default-run = "xargo"
 
 [dependencies]


### PR DESCRIPTION
r? @jethrogb 

Would be good to get this out ASAP, it blocks https://github.com/rust-lang/miri/pull/1490.