### PR TITLE
update CI config for travis-ci.com

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,9 @@ matrix:
       if: branch = staging OR branch = trying
 
     # OSX (build only)
-    - env: TARGET=x86_64-apple-darwin
-      os: osx
-      if: branch = staging OR branch = trying
+    #- env: TARGET=x86_64-apple-darwin
+    #  os: osx
+    #  if: branch = staging OR branch = trying
 
 install:
   - bash ci/install.sh

--- a/bors.toml
+++ b/bors.toml
@@ -1,3 +1,3 @@
 status = [
-  "continuous-integration/travis-ci/push",
+  "Travis CI - Branch",
 ]


### PR DESCRIPTION
Sadly this means we need to disable macOS. CI will need to be ported to GitHub Actions (or something else) to get a macOS builder again.

Fixes https://github.com/japaric/xargo/issues/305