### PR TITLE
Fix copy failure by overriding CARGO_TARGET_DIR

### DIFF
--- a/src/sysroot.rs
+++ b/src/sysroot.rs
@@ -128,7 +128,10 @@ version = "0.0.0"
                 writeln!(io::stderr(), "+ RUSTFLAGS={:?}", flags).ok();
             }
             cmd.env("RUSTFLAGS", flags);
-            cmd.env_remove("CARGO_TARGET_DIR");
+
+            // Since we currently don't want to respect `.cargo/config` or `CARGO_TARGET_DIR`,
+            // we need to force the target directory to match the `cp_r` below.
+            cmd.env("CARGO_TARGET_DIR", td.join("target"));
 
             // Workaround #261.
             //


### PR DESCRIPTION
Fixes #286 

According to @RalfJung (https://github.com/japaric/xargo/issues/286#issuecomment-607675112). It's better to use default `target`. So we just need to explicit override the target directory to fix the copy failure.

> xargo has its own workspace for building libstd. There is no interaction whatsoever with the workspace of your project. That's why I keep saying xargo should just overwrite the target dir.