### PR TITLE
Get rid of now-unnecessary ci-failure job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,14 +108,3 @@ jobs:
     steps:
       - name: CI succeeded
         run: exit 0
-
-  ci-failure:
-    name: ci
-    if: ${{ !success() }}
-    needs:
-      - build
-      - test
-    runs-on: ubuntu-20.04
-    steps:
-      - name: CI failed
-        run: exit 1


### PR DESCRIPTION
Fix bors-ng/bors-ng#1129

Sorry about breaking your workflow.