### PR TITLE
remove 'dev' feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,12 +90,6 @@ jobs:
         with:
           command: test
 
-      - name: Test (+dev)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --features dev
-
   # Refs: https://github.com/rust-lang/crater/blob/9ab6f9697c901c4a44025cf0a39b73ad5b37d198/.github/workflows/bors.yml#L125-L149
   # bors.tech integration
   ci-success:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,3 @@ dirs = "3.0"
 [dev-dependencies]
 lazy_static = "1.0.0"
 parking_lot = "0.11"
-
-[features]
-dev = []

--- a/src/sysroot.rs
+++ b/src/sysroot.rs
@@ -18,12 +18,6 @@ use util;
 use xargo::Home;
 use {cargo, xargo};
 
-#[cfg(feature = "dev")]
-fn profile() -> &'static str {
-    "debug"
-}
-
-#[cfg(not(feature = "dev"))]
 fn profile() -> &'static str {
     "release"
 }
@@ -177,14 +171,7 @@ version = "0.0.0"
                 XargoMode::Check => cmd.arg("check")
             };
 
-            match () {
-                #[cfg(feature = "dev")]
-                () => {}
-                #[cfg(not(feature = "dev"))]
-                () => {
-                    cmd.arg("--release");
-                }
-            }
+            cmd.arg("--release");
             cmd.arg("--manifest-path");
             cmd.arg(td.join("Cargo.toml"));
             cmd.args(&["--target", cmode.triple()]);

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -1,6 +1,4 @@
-#![cfg_attr(not(feature = "dev"), allow(dead_code))]
 #![deny(warnings)]
-#![feature(const_fn)]
 
 #[macro_use]
 extern crate error_chain;
@@ -392,7 +390,6 @@ impl Drop for HProject {
 }
 
 /// Test vanilla `xargo build`
-#[cfg(feature = "dev")]
 #[test]
 fn simple() {
     fn run() -> Result<()> {
@@ -410,7 +407,6 @@ fn simple() {
 
 /// Test building a dependency specified as `target.{}.dependencies` in
 /// ../Xargo.toml
-#[cfg(feature = "dev")]
 #[test]
 fn target_dependencies() {
     fn run() -> Result<()> {
@@ -445,7 +441,6 @@ path = "stage1"
 }
 
 /// Test building a dependency specified as `dependencies` in Xargo.toml
-#[cfg(feature = "dev")]
 #[test]
 fn dependencies() {
     fn run() -> Result<()> {
@@ -469,7 +464,6 @@ fn dependencies() {
 }
 
 /// Test that `xargo build` can be executed from outside project dir
-#[cfg(feature = "dev")]
 #[test]
 fn build_outside_project_dir() {
     fn run() -> Result<()> {
@@ -494,7 +488,6 @@ fn build_outside_project_dir() {
 }
 
 /// Test `xargo doc`
-#[cfg(feature = "dev")]
 #[test]
 fn doc() {
     fn run() -> Result<()> {
@@ -511,7 +504,6 @@ fn doc() {
 }
 
 /// Check that calling `xargo build` a second time doesn't rebuild the sysroot
-#[cfg(feature = "dev")]
 #[test]
 fn twice() {
     fn run() -> Result<()> {
@@ -534,7 +526,6 @@ fn twice() {
 
 /// Check that if `build.target` is set in `.cargo/config`, that target will be
 /// used to build the sysroot
-#[cfg(feature = "dev")]
 #[test]
 fn build_target() {
     fn run() -> Result<()> {
@@ -559,7 +550,6 @@ target = "thumbv6m-build_target-eabi"
 }
 
 /// Check that `--target` overrides `build.target`
-#[cfg(feature = "dev")]
 #[test]
 fn override_build_target() {
     fn run() -> Result<()> {
@@ -584,7 +574,6 @@ target = "BAD"
 }
 
 /// We shouldn't rebuild the sysroot if `profile.release.lto` changed
-#[cfg(feature = "dev")]
 #[test]
 fn lto_changed() {
     fn run() -> Result<()> {
@@ -613,7 +602,6 @@ lto = true
 }
 
 /// Modifying RUSTFLAGS should trigger a rebuild of the sysroot
-#[cfg(feature = "dev")]
 #[test]
 fn rustflags_changed() {
     fn run() -> Result<()> {
@@ -642,7 +630,6 @@ rustflags = ["--cfg", "xargo"]
 }
 
 /// Check that RUSTFLAGS are passed to all `rustc`s
-#[cfg(feature = "dev")]
 #[test]
 fn rustflags() {
     fn run() -> Result<()> {
@@ -675,7 +662,6 @@ rustflags = ["--cfg", "xargo"]
 
 /// Check that `-C panic=abort` is passed to `rustc` when `panic = "abort"` is
 /// set in `profile.release`
-#[cfg(not(feature = "dev"))]
 #[test]
 fn panic_abort() {
     fn run() -> Result<()> {
@@ -706,7 +692,6 @@ panic = "abort"
 }
 
 /// Check that adding linker arguments doesn't trigger a sysroot rebuild
-#[cfg(feature = "dev")]
 #[test]
 fn link_arg() {
     fn run() -> Result<()> {
@@ -736,7 +721,6 @@ rustflags = ["-C", "link-arg=-lfoo"]
 }
 
 /// The sysroot should be rebuilt if the target specification changed
-#[cfg(feature = "dev")]
 #[test]
 fn specification_changed() {
     fn run() -> Result<()> {
@@ -780,7 +764,6 @@ fn specification_changed() {
 
 /// The sysroot should NOT be rebuilt if the target specification didn't really
 /// changed, e.g. some fields were moved around
-#[cfg(feature = "dev")]
 #[test]
 fn unchanged_specification() {
     fn run() -> Result<()> {
@@ -822,7 +805,6 @@ fn unchanged_specification() {
 }
 
 /// Check that a sysroot is built for the host
-#[cfg(feature = "dev")]
 #[test]
 fn host_once() {
     fn run() -> Result<()> {
@@ -841,7 +823,6 @@ fn host_once() {
 
 /// Check that the sysroot is not rebuilt when `xargo build` is called a second
 /// time
-#[cfg(feature = "dev")]
 #[test]
 fn host_twice() {
     fn run() -> Result<()> {
@@ -863,7 +844,6 @@ fn host_twice() {
 }
 
 /// Check we can build+run `xargo test`
-#[cfg(feature = "dev")]
 #[test]
 fn host_libtest() {
     fn run() -> Result<()> {
@@ -885,7 +865,6 @@ features = [\"panic_unwind\"]
 }
 
 /// Check multi stage sysroot builds with `xargo build`
-#[cfg(feature = "dev")]
 #[test]
 fn host_liballoc() {
     fn run() -> Result<()> {
@@ -910,7 +889,6 @@ stage = 1
 /// Test having a `[patch]` section.
 /// The tag in the toml file needs to be updated any time the version of
 /// cc used by rustc is updated.
-#[cfg(feature = "dev")]
 #[test]
 fn host_patch() {
     fn run() -> Result<()> {
@@ -945,7 +923,6 @@ tag = "1.0.47"
     }
 }
 
-#[cfg(feature = "dev")]
 #[test]
 fn cargo_check_check() {
     fn run() -> Result<()> {
@@ -957,7 +934,6 @@ fn cargo_check_check() {
     run!()
 }
 
-#[cfg(feature = "dev")]
 #[test]
 fn cargo_check_check_no_ctoml() {
     fn run() -> Result<()> {


### PR DESCRIPTION
I am not entirely sure why this was added, but not having `cargo test` run the main test suite has been eternally confusing... I think we better just get rid of this feature.