### PR TITLE
release xargo 0.3.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [v0.3.24] - 2021-09-??
+
+### Fixed
+
+- Fix `compiler_builtins` error when building without explicit dependencies in
+  the `Xargo.toml` (thanks to @anickol).
+
 ## [v0.3.23] - 2021-05-08
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,7 +465,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "xargo"
-version = "0.3.23"
+version = "0.3.24"
 dependencies = [
  "dirs",
  "error-chain",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["cli", "cross", "compilation", "std"]
 license = "MIT OR Apache-2.0"
 name = "xargo"
 repository = "https://github.com/japaric/xargo"
-version = "0.3.23"
+version = "0.3.24"
 default-run = "xargo"
 
 [dependencies]


### PR DESCRIPTION
We should get the fix to https://github.com/japaric/xargo/issues/320 shipped.
@jethrogb any objections?