### PR TITLE
release xargo 0.3.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [v0.3.26] - 2022-06-01
+
+### Fixed
+
+- Fix handling spaces in the sysroot path.
+
 ## [v0.3.25] - 2022-03-26
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,7 +498,7 @@ checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
 
 [[package]]
 name = "xargo"
-version = "0.3.25"
+version = "0.3.26"
 dependencies = [
  "dirs",
  "error-chain",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["cli", "cross", "compilation", "std"]
 license = "MIT OR Apache-2.0"
 name = "xargo"
 repository = "https://github.com/japaric/xargo"
-version = "0.3.25"
+version = "0.3.26"
 default-run = "xargo"
 
 [dependencies]


### PR DESCRIPTION
Let's get https://github.com/japaric/xargo/pull/336 out there.