### PR TITLE
replace unmainted `fs2` with `fs3`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,12 +87,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs2"
-version = "0.4.3"
+name = "fs3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+checksum = "fb17cf6ed704f72485332f6ab65257460c4f9f3083934cf402bf9f5b3b600a90"
 dependencies = [
  "libc",
+ "rustc_version 0.2.3",
  "winapi",
 ]
 
@@ -133,9 +134,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.121"
+version = "0.2.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
+checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
 
 [[package]]
 name = "lock_api"
@@ -286,11 +287,20 @@ checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver",
+ "semver 1.0.6",
 ]
 
 [[package]]
@@ -316,9 +326,24 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a3381e03edd24287172047536f20cabde766e2cd3e65e6b00fb3af51c4f38d"
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
@@ -502,11 +527,11 @@ version = "0.3.26"
 dependencies = [
  "dirs",
  "error-chain",
- "fs2",
+ "fs3",
  "lazy_static",
  "libc",
  "parking_lot",
- "rustc_version",
+ "rustc_version 0.4.0",
  "serde_json",
  "tempdir",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ default-run = "xargo"
 
 [dependencies]
 error-chain = { version = "0.12", default-features = false }
-fs2 = "0.4.1"
 libc = "0.2.18"
 rustc_version = "0.4"
 serde_json = "1.0"
@@ -21,6 +20,7 @@ tempdir = "0.3.5"
 toml = "0.5.6"
 walkdir = "2.3"
 dirs = "4.0"
+fs3 = "0.5.0"
 
 [dev-dependencies]
 lazy_static = "1.0.0"

--- a/src/flock.rs
+++ b/src/flock.rs
@@ -6,8 +6,8 @@ use std::io::Write;
 use std::path::{Display, Path, PathBuf};
 use std::{fs, io};
 
-use fs2::FileExt;
-use fs2;
+use fs3::FileExt;
+use fs3;
 
 #[derive(PartialEq)]
 enum State {
@@ -177,7 +177,7 @@ fn acquire(
         {
             return Ok(())
         }
-        Err(e) => if e.raw_os_error() != fs2::lock_contended_error().raw_os_error() {
+        Err(e) => if e.raw_os_error() != fs3::lock_contended_error().raw_os_error() {
             return Err(e);
         },
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,9 @@
 
 #[macro_use]
 extern crate error_chain;
-extern crate fs2;
 #[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "macos"))]
 extern crate libc;
+extern crate fs3;
 extern crate rustc_version;
 extern crate serde_json;
 extern crate tempdir;


### PR DESCRIPTION
`xargo` would not build on illumos, due to a build failure in the unmaintained `fs2` crate.  Replace that with the `fs3` crate that has a current maintainer.

Signed-off-by: Dan Cross <cross@oxidecomputer.com>