### PR TITLE
Fix building with Rust 1.89.0

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -3,13 +3,13 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus};
 use std::{env, fmt};
 
-use toml::{Value, map::Map};
+use toml::{map::Map, Value};
 
 use cli::Args;
 use errors::*;
 use extensions::CommandExt;
-use util;
 use sysroot::XargoMode;
+use util;
 use xargo::Home;
 
 #[derive(Clone)]
@@ -50,7 +50,7 @@ impl Rustflags {
     pub fn encode(mut self, home: &Home) -> String {
         self.flags.push("--sysroot".to_owned());
         self.flags.push(home.display().to_string()); // FIXME: we shouldn't use display, we should keep the OsString
-        // As per CARGO_ENCODED_RUSTFLAGS docs, the separator is `0x1f`.
+                                                     // As per CARGO_ENCODED_RUSTFLAGS docs, the separator is `0x1f`.
         self.flags.join("\x1f")
     }
 }
@@ -75,7 +75,7 @@ impl Rustdocflags {
     pub fn encode(mut self, home: &Home) -> String {
         self.flags.push("--sysroot".to_owned());
         self.flags.push(home.display().to_string()); // FIXME: we shouldn't use display, we should keep the OsString
-        // As per CARGO_ENCODED_RUSTFLAGS docs, the separator is `0x1f`.
+                                                     // As per CARGO_ENCODED_RUSTFLAGS docs, the separator is `0x1f`.
         self.flags.join("\x1f")
     }
 }
@@ -84,19 +84,17 @@ pub fn rustdocflags(config: Option<&Config>, target: &str) -> Result<Rustdocflag
     flags(config, target, "rustdocflags").map(|fs| Rustdocflags { flags: fs })
 }
 
-
 /// Returns the flags for `tool` (e.g. rustflags)
 ///
 /// This looks into the environment and into `.cargo/config`
 fn flags(config: Option<&Config>, target: &str, tool: &str) -> Result<Vec<String>> {
     // TODO: would be nice to also support the CARGO_ENCODED_ env vars
     if let Some(t) = env::var_os(tool.to_uppercase()) {
-        return Ok(
-            t.to_string_lossy()
-                .split_whitespace()
-                .map(|w| w.to_owned())
-                .collect(),
-        );
+        return Ok(t
+            .to_string_lossy()
+            .split_whitespace()
+            .map(|w| w.to_owned())
+            .collect());
     }
 
     if let Some(config) = config.as_ref() {
@@ -109,7 +107,8 @@ fn flags(config: Option<&Config>, target: &str, tool: &str) -> Result<Vec<String
             .or_else(|| {
                 build = true;
                 config.table.get("build").and_then(|t| t.get(tool))
-            }) {
+            })
+        {
             let mut flags = vec![];
 
             let mut error = false;
@@ -137,8 +136,7 @@ fn flags(config: Option<&Config>, target: &str, tool: &str) -> Result<Vec<String
                     Err(format!(
                         ".cargo/config: target.{}.{} must be an \
                          array of strings",
-                        target,
-                        tool
+                        target, tool
                     ))?
                 }
             } else {
@@ -159,9 +157,7 @@ pub fn command() -> Command {
 }
 
 pub fn run(args: &Args, verbose: bool) -> Result<ExitStatus> {
-    command()
-        .args(args.all())
-        .run_and_get_status(verbose)
+    command().args(args.all()).run_and_get_status(verbose)
 }
 
 pub struct Config {
@@ -171,8 +167,9 @@ pub struct Config {
 impl Config {
     pub fn target(&self) -> Result<Option<&str>> {
         if let Some(v) = self.table.get("build").and_then(|t| t.get("target")) {
-            Ok(Some(v.as_str()
-                .ok_or_else(|| format!(".cargo/config: build.target must be a string"))?))
+            Ok(Some(v.as_str().ok_or_else(|| {
+                format!(".cargo/config: build.target must be a string")
+            })?))
         } else {
             Ok(None)
         }
@@ -262,7 +259,7 @@ pub fn root(mode: XargoMode, manifest_path: Option<&str>) -> Result<Option<Root>
     // Don't require a 'Cargo.toml' to exist when 'xargo-check' is used
     let name = match mode {
         XargoMode::Build => "Cargo.toml",
-        XargoMode::Check => "Xargo.toml"
+        XargoMode::Check => "Xargo.toml",
     };
 
     let cd = match manifest_path {

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -233,7 +233,7 @@ pub struct Toml {
 
 impl Toml {
     /// `profile.release` part of `Cargo.toml`
-    pub fn profile(&self) -> Option<Profile> {
+    pub fn profile(&self) -> Option<Profile<'_>> {
         self.table
             .get("profile")
             .and_then(|t| t.get("release"))

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,7 +7,7 @@ pub struct Args {
     subcommand: Option<Subcommand>,
     target: Option<String>,
     message_format: Option<String>,
-    manifest_path: Option<String>,  // path to the Cargo toml file given in --manifest-path
+    manifest_path: Option<String>, // path to the Cargo toml file given in --manifest-path
 }
 
 impl Args {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,3 +1,4 @@
 #![allow(unknown_lints)]
 #![allow(unused_doc_comments)]
+#![allow(unexpected_cfgs)]
 error_chain!();

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -1,5 +1,5 @@
-use std::io::Write;
 use std::io;
+use std::io::Write;
 use std::process::{Command, ExitStatus};
 
 use errors::*;
@@ -42,7 +42,8 @@ impl CommandExt for Command {
             writeln!(io::stderr(), "+ {:?}", self).ok();
         }
 
-        let out = self.output()
+        let out = self
+            .output()
             .chain_err(|| format!("couldn't execute `{:?}`", self))?;
 
         if out.status.success() {

--- a/src/flock.rs
+++ b/src/flock.rs
@@ -112,7 +112,9 @@ impl Filesystem {
                 })?;
             }
             State::Shared => {
-                acquire(msg, &path, &|| f.try_lock_shared(), &|| f.lock_shared())?;
+                acquire(msg, &path, &|| Ok(f.try_lock_shared()?), &|| {
+                    f.lock_shared()
+                })?;
             }
         }
 
@@ -122,7 +124,7 @@ impl Filesystem {
         })
     }
 
-    pub fn display(&self) -> Display {
+    pub fn display(&self) -> Display<'_> {
         self.path.display()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,19 +2,22 @@
 
 #[macro_use]
 extern crate error_chain;
+extern crate dirs;
 extern crate fs2;
-#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "macos"))]
+#[cfg(any(
+    all(target_os = "linux", not(target_env = "musl")),
+    target_os = "macos"
+))]
 extern crate libc;
 extern crate rustc_version;
 extern crate serde_json;
 extern crate tempdir;
 extern crate toml;
 extern crate walkdir;
-extern crate dirs;
 
 use std::hash::{Hash, Hasher};
 use std::io::Write;
-use std::path::{Path};
+use std::path::Path;
 use std::process::ExitStatus;
 use std::{env, io, process};
 
@@ -100,9 +103,11 @@ pub fn main_inner(xargo_mode: XargoMode) {
 
             process::exit(1)
         }
-        Ok(Some(status)) => if !status.success() {
-            process::exit(status.code().unwrap_or(1))
-        },
+        Ok(Some(status)) => {
+            if !status.success() {
+                process::exit(status.code().unwrap_or(1))
+            }
+        }
         Ok(None) => {}
     }
 }
@@ -122,7 +127,8 @@ fn run(cargo_mode: XargoMode) -> Result<Option<ExitStatus>> {
             io::stderr(),
             concat!("xargo ", env!("CARGO_PKG_VERSION"), "{}"),
             include_str!(concat!(env!("OUT_DIR"), "/commit-info.txt"))
-        ).ok();
+        )
+        .ok();
 
         return cargo::run(&args, verbose).map(Some);
     }
@@ -136,11 +142,13 @@ fn run(cargo_mode: XargoMode) -> Result<Option<ExitStatus>> {
                 "The XARGO_RUST_SRC env variable must be set and point to the \
                  Rust source directory when working with the 'dev' channel",
             )?,
-            Channel::Nightly => if let Some(src) = rustc::Src::from_env() {
-                src
-            } else {
-                sysroot.src()?
-            },
+            Channel::Nightly => {
+                if let Some(src) = rustc::Src::from_env() {
+                    src
+                } else {
+                    sysroot.src()?
+                }
+            }
             Channel::Stable | Channel::Beta => {
                 eprintln!(
                     "ERROR: the sysroot can't be built for the {:?} channel. \
@@ -199,13 +207,13 @@ fn run(cargo_mode: XargoMode) -> Result<Option<ExitStatus>> {
                     &meta,
                     config.as_ref(),
                     verbose,
-                ).map(Some);
+                )
+                .map(Some);
             } else {
-                return Ok(None)
+                return Ok(None);
             }
         }
     }
 
     cargo::run(&args, verbose).map(Some)
 }
-

--- a/src/rustc.rs
+++ b/src/rustc.rs
@@ -5,13 +5,13 @@ use std::process::Command;
 
 pub use rustc_version::version_meta as version;
 
-use serde_json::Value;
 use serde_json;
+use serde_json::Value;
 
+use cargo::Root;
 use errors::*;
 use extensions::CommandExt;
 use {rustc, util};
-use cargo::Root;
 
 fn command() -> Command {
     env::var_os("RUSTC")
@@ -32,10 +32,8 @@ pub fn sysroot(verbose: bool) -> Result<Sysroot> {
     command()
         .args(&["--print", "sysroot"])
         .run_and_get_stdout(verbose)
-        .map(|l| {
-            Sysroot {
-                path: PathBuf::from(l.trim()),
-            }
+        .map(|l| Sysroot {
+            path: PathBuf::from(l.trim()),
         })
 }
 /// Path to Rust source
@@ -74,22 +72,32 @@ impl Sysroot {
     pub fn src(&self) -> Result<Src> {
         let src = self.path().join("lib").join("rustlib").join("src");
 
-        if src.join("rust").join("src").join("libstd").join("Cargo.toml").is_file() {
+        if src
+            .join("rust")
+            .join("src")
+            .join("libstd")
+            .join("Cargo.toml")
+            .is_file()
+        {
             return Ok(Src {
                 path: src.join("rust").join("src"),
             });
         }
 
-        if src.join("rust").join("library").join("std").join("Cargo.toml").is_file() {
+        if src
+            .join("rust")
+            .join("library")
+            .join("std")
+            .join("Cargo.toml")
+            .is_file()
+        {
             return Ok(Src {
                 path: src.join("rust").join("library"),
             });
         }
 
-        Err(
-            "`rust-src` component not found. Run `rustup component add \
-             rust-src`.",
-        )?
+        Err("`rust-src` component not found. Run `rustup component add \
+             rust-src`.")?
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,7 @@
+use std::fs;
 use std::fs::File;
 use std::io::{Read, Write};
 use std::path::Path;
-use std::fs;
 
 use toml::Value;
 use walkdir::WalkDir;
@@ -31,15 +31,14 @@ pub fn cp_r(src: &Path, dst: &Path) -> Result<()> {
         })?;
 
         let dst_file = dst.join(relative_path);
-        let metadata = e.metadata().chain_err(|| {
-            format!("Could not retrieve metadata of `{}`", e.path().display())
-        })?;
+        let metadata = e
+            .metadata()
+            .chain_err(|| format!("Could not retrieve metadata of `{}`", e.path().display()))?;
 
         if metadata.is_dir() {
             // ensure the destination directory exists
-            fs::create_dir_all(&dst_file).chain_err(|| {
-                format!("Could not create directory `{}`", dst_file.display())
-            })?;
+            fs::create_dir_all(&dst_file)
+                .chain_err(|| format!("Could not create directory `{}`", dst_file.display()))?;
         } else {
             // else copy the file
             fs::copy(&src_file, &dst_file).chain_err(|| {
@@ -61,8 +60,10 @@ pub fn mkdir(path: &Path) -> Result<()> {
 
 /// Parses `path` as TOML
 pub fn parse(path: &Path) -> Result<Value> {
-    Ok(toml::from_str(&read(path)?)
-        .map_err(|_| format!("{} is not valid TOML", path.display()))?)
+    Ok(
+        toml::from_str(&read(path)?)
+            .map_err(|_| format!("{} is not valid TOML", path.display()))?,
+    )
 }
 
 pub fn read(path: &Path) -> Result<String> {

--- a/src/xargo.rs
+++ b/src/xargo.rs
@@ -1,17 +1,17 @@
+use std::io::{self, Write};
 use std::path::{Display, Path, PathBuf};
 use std::process::ExitStatus;
 use std::{env, mem};
-use std::io::{self, Write};
 
-use toml::Value;
 use rustc_version::VersionMeta;
+use toml::Value;
 
-use CompilationMode;
 use cargo::{Config, Root, Rustflags, Subcommand};
 use cli::Args;
 use errors::*;
 use extensions::CommandExt;
 use flock::{FileLock, Filesystem};
+use CompilationMode;
 use {cargo, util};
 
 pub fn run(
@@ -64,18 +64,14 @@ impl Home {
         let fs = self.path(triple);
 
         fs.open_ro(".sentinel", &format!("{}'s sysroot", triple))
-            .chain_err(|| {
-                format!("couldn't lock {}'s sysroot as read-only", triple)
-            })
+            .chain_err(|| format!("couldn't lock {}'s sysroot as read-only", triple))
     }
 
     pub fn lock_rw(&self, triple: &str) -> Result<FileLock> {
         let fs = self.path(triple);
 
         fs.open_rw(".sentinel", &format!("{}'s sysroot", triple))
-            .chain_err(|| {
-                format!("couldn't lock {}'s sysroot as read-only", triple)
-            })
+            .chain_err(|| format!("couldn't lock {}'s sysroot as read-only", triple))
     }
 }
 
@@ -125,9 +121,11 @@ impl Toml {
 /// content of this 'Xargo.toml'
 pub fn toml(root: &Root) -> Result<(Option<&Path>, Option<Toml>)> {
     if let Some(p) = util::search(root.path(), "Xargo.toml") {
-        Ok((Some(p), util::parse(&p.join("Xargo.toml")).map(|t| Some(Toml { table: t }))?))
-    }
-    else {
+        Ok((
+            Some(p),
+            util::parse(&p.join("Xargo.toml")).map(|t| Some(Toml { table: t }))?,
+        ))
+    } else {
         Ok((None, None))
     }
 }

--- a/src/xargo.rs
+++ b/src/xargo.rs
@@ -52,7 +52,7 @@ pub struct Home {
 }
 
 impl Home {
-    pub fn display(&self) -> Display {
+    pub fn display(&self) -> Display<'_> {
         self.path.display()
     }
 

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -22,6 +22,7 @@ use errors::*;
 
 mod errors {
     #![allow(unused_doc_comments)]
+    #![allow(unexpected_cfgs)]
     error_chain!();
 }
 


### PR DESCRIPTION
This includes the minimal necessary updates to get `xargo` compiling with the latest Rust toolchain. No functional changes were made - just adjustments to ensure compatibility... also applied code formatting using `cargo fmt`.